### PR TITLE
squid-save: execute sssd-initkeytabs

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -54,6 +54,7 @@ my $event = "nethserver-squid-save";
 
 event_actions($event, qw(
    nethserver-squid-check-cache 20
+   nethserver-sssd-initkeytabs  20
    firewall-adjust 30
 ));
 


### PR DESCRIPTION
Make sure kerberos ticket is generated before squid is started.

NethServer/dev#5259