### PR TITLE
squid.conf: always add https acl

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/40ports
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/40ports
@@ -14,6 +14,10 @@
    if ($green_mode eq 'transparent_ssl' || (defined($ndb->blue()) && $blue_mode eq 'transparent_ssl')) {
        $OUT.="\n# Enable SSL transparent proxy
 https_port 3130 intercept ssl-bump generate-host-certificates=off cert=/etc/pki/tls/certs/NSRV.crt key=/etc/pki/tls/private/NSRV.key sslflags=NO_DEFAULT_CA options=NO_SSLv2,NO_SSLv3,No_Compression dynamic_cert_mem_cache_size=128KB
+";
+   }
+}
+
 acl https_proto proto https
 always_direct allow https_proto
 ssl_bump none localhost
@@ -28,7 +32,3 @@ ssl_bump peek tls_s1_connect all
 ssl_bump splice all
 # peek at TLS/SSL connect data
 # splice: no active bumping
-";
-   }
-}
-


### PR DESCRIPTION
I'd like to always have https related acl in squid.conf, to be able to use them from template fragments added by external packages.
I have tested this code, it does what I need, but it could probably be written differently.
