### PR TITLE
Squid: bypass domain names

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -24,6 +24,10 @@ source_file = root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_P
 source_lang = en
 type = PHP_ALT_ARRAY
 
+[nethserver.Proxy_BypassDomains]
+source_file = root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Proxy_BypassDomains.php
+source_lang = en
+type = PHP_ALT_ARRAY
 
 [nethserver.Proxy_Config]
 source_file = root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Proxy_Config.php

--- a/createlinks
+++ b/createlinks
@@ -33,6 +33,7 @@ event_actions($event, qw(
    initialize-default-databases 00
    nethserver-sssd-initkeytabs  20
    nethserver-squid-check-cache 30
+   nethserver-squid-ipset       50
 ));
 
 templates2events("/etc/squid/squid.conf",  $event);
@@ -55,6 +56,7 @@ my $event = "nethserver-squid-save";
 event_actions($event, qw(
    nethserver-squid-check-cache 20
    nethserver-sssd-initkeytabs  20
+   nethserver-squid-ipset       50
    firewall-adjust 30
 ));
 

--- a/root/etc/e-smith/events/actions/nethserver-squid-ipset
+++ b/root/etc/e-smith/events/actions/nethserver-squid-ipset
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# Manage ipset for squid bypass
+
+NAME=squid-bypass
+TIMEOUT=300
+
+ipset list $NAME 2>/dev/null
+
+# Create the ipset if not exists
+if [ $? -gt 0 ]; then
+    ipset create $NAME iphash timeout $TIMEOUT
+else
+# otherwise flush it
+    ipset flush $NAME
+fi
+

--- a/root/etc/e-smith/events/actions/nethserver-squid-ipset
+++ b/root/etc/e-smith/events/actions/nethserver-squid-ipset
@@ -23,7 +23,7 @@
 # Manage ipset for squid bypass
 
 NAME=squid-bypass
-TIMEOUT=300
+TIMEOUT=43200 # 12 hours
 
 ipset list $NAME 2>/dev/null
 

--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/25squid_ipset
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/25squid_ipset
@@ -1,0 +1,11 @@
+{
+    my $status = $squid{'status'} || 'disabled';
+    my $list = $squid{'BypassDomains'} || '';
+    if ($status eq 'enabled' && $list ne '') {
+        $list =~ s/,/\//g;
+        $OUT.="#\n";
+        $OUT.="# 25squid_ipset - Squid domain bypass using ipset\n";
+        $OUT.="#\n";
+        $OUT.="ipset=/$list/squid-bypass\n\n\n";
+    }
+}

--- a/root/etc/e-smith/templates/etc/shorewall/rules/90squid
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/90squid
@@ -12,6 +12,7 @@
     my $green_mode = $squid{'GreenMode'} || 'manual';
     my $blue_mode = $squid{'BlueMode'} || 'manual';
     my $block = $squid{'PortBlock'} || 'disabled';
+    my $bypass_domain_list = $squid{'BypassDomains'} ? '+squid-bypass' : '';
     
     my %zones;
     my @ips;
@@ -44,6 +45,9 @@
         my $bypass_dst_str = '';
         push(@bypass_dst, @interfaces);
         push(@bypass_dst, @ips);
+        if ($bypass_domain_list ne '') {
+            push(@bypass_dst, $bypass_domain_list);
+        }
 
         if ( $green_mode =~ /transparent/ || (defined($ndb->blue()) && $blue_mode =~ /transparent/) ) {
 

--- a/root/etc/systemd/system/dnsmasq.service.d/ipset.conf
+++ b/root/etc/systemd/system/dnsmasq.service.d/ipset.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/etc/e-smith/events/actions/nethserver-squid-ipset

--- a/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Proxy.rst
+++ b/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Proxy.rst
@@ -36,6 +36,14 @@ Parent proxy
     IP_Address:port.
     *DO NOT* enter the IP address of this server.
 
+Domains without proxy
+=====================
+
+List of domains bypassed when transparent proxy is enabled.
+
+Domains
+    List of domains, one per line.
+
 Hosts without proxy
 ===================
 

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Proxy_BypassDomains.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Proxy_BypassDomains.php
@@ -1,0 +1,4 @@
+<?php
+
+$L['BypassDomains_Title'] = 'Domains without proxy';
+$L['BypassDomains_label'] = 'Domains';

--- a/root/usr/share/nethesis/NethServer/Module/Proxy/BypassDomains.php
+++ b/root/usr/share/nethesis/NethServer/Module/Proxy/BypassDomains.php
@@ -1,0 +1,73 @@
+<?php
+namespace NethServer\Module\Proxy;
+
+/*
+ * Copyright (C) 2017 Nethesis S.r.l.
+ *
+ * This script is part of NethServer.
+ *
+ * NethServer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NethServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Nethgui\System\PlatformInterface as Validate;
+
+/**
+ * Configure squid byapss domains
+ *
+ */
+class BypassDomains extends \Nethgui\Controller\AbstractController
+{
+
+    public $sortId = 20;
+
+
+    // Declare all parameters
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->declareParameter('BypassDomains', Validate::ANYTHING, array('configuration', 'squid', 'BypassDomains'));
+    }
+
+    public function readBypassDomains($v)
+    {
+        return implode("\n", explode(",", $v));
+    }
+
+    public function writeBypassDomains($p)
+    {
+        return array(implode(',', array_filter(preg_split("/[,\s]+/", $p))));
+    }
+
+    public function validate(\Nethgui\Controller\ValidationReportInterface $report)
+    {
+        parent::validate($report);
+        if (!$this->getRequest()->isMutation()) {
+            return;
+        }
+
+        $hostnameValidator = $this->createValidator(Validate::HOSTNAME_FQDN);
+        $domains = array_filter(preg_split('/[,\s]+/', $this->parameters['BypassDomains']));
+        foreach ($domains as $domain){
+            if( ! $hostnameValidator->evaluate($domain)) {
+                $report->addValidationErrorMessage($this, 'BypassDomains', "'$domain' is not a valid domain");
+            }
+        }
+    }
+
+    protected function onParametersSaved($changes)
+    {
+        $this->getPlatform()->signalEvent('nethserver-squid-save &');
+    }
+}

--- a/root/usr/share/nethesis/NethServer/Template/Proxy/BypassDomains.php
+++ b/root/usr/share/nethesis/NethServer/Template/Proxy/BypassDomains.php
@@ -1,0 +1,7 @@
+<?php
+
+echo $view->panel()
+        ->insert($view->textArea('BypassDomains', $view::LABEL_ABOVE)->setAttribute('dimensions', '10x50'))
+;
+
+echo $view->buttonList($view::BUTTON_SUBMIT | $view::BUTTON_CANCEL | $view::BUTTON_HELP);


### PR DESCRIPTION
Implement Squid transparent bypass using domain names.

The feature uses an ipset named ``squid-byass`` which is populated by dnsmasq.
Every entry inside the ipset will be discarded after 300 seconds.

NethServer/dev#5299

In nethserver-testing:
nethserver-squid-1.5.4-1.8.g6434e3f.ns7.noarch.rpm