### PR TITLE
Make sure logs go to access.log

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
@@ -1,0 +1,20 @@
+#
+# 20acl_95_localnet_log
+# Make sure logs go to access.log
+# Put custom logging config above this section
+#
+{
+    use esmith::NetworksDB;
+
+    $OUT.="access_log daemon:/var/log/squid/access.log squid localnet\n";
+
+    my $ndb = esmith::NetworksDB->open_ro();
+    foreach ( $ndb->blue() ) {
+        my $ip = $_->prop('ipaddr') || next;
+        my $mask = $_->prop('netmask') || next;
+        $OUT.="access_log daemon:/var/log/squid/access.log squid blue\n";
+        last;
+    }
+
+}
+


### PR DESCRIPTION
Without this patch, if dedalo hotspot was not installed, the access.log was always empty.