### PR TITLE
Allow access to cockpit

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_00_ports
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_00_ports
@@ -1,6 +1,7 @@
 # Safe ports
 acl SSL_ports port 443
 acl SSL_ports port 980		# httpd-admin (server-manager)
+acl SSL_ports port 9090		# Cockpit Web UI
 acl Safe_ports port 80		# http
 acl Safe_ports port 21		# ftp
 acl Safe_ports port 443		# https


### PR DESCRIPTION
Allow SSL access to port 9090 by default, to access Cockpit Web UI from a client using the squid web proxy.
Note: without this configuration line, the browser says that the proxy is not responding, while squid/access.log logs a TCP_DENIED/403.
