### PR TITLE
Improve charts unavailable label

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -22,7 +22,7 @@
   "no": "No",
   "configure": "Configure",
   "charts": "Charts",
-  "charts_not_updated": "Charts cannot be updated.",
+  "charts_not_updated": "Charts cannot be updated. Maybe Netdata is not installed or is not running",
   "charts_not_available": "Charts not available if proxy is disabled.",
   "show_charts": "Show charts",
   "hide_charts": "Hide charts",


### PR DESCRIPTION
Use a more descriptive label when charts cannot be shown
See community discussion at https://community.nethserver.org/t/web-proxy-filter-dashboard-not-work/13363