### PR TITLE
Create the contentfilter DB if not exists

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -121,7 +121,7 @@ if ($cmd eq 'status') {
     $ret->{'proxy'}{'cpu_usage'} = sprintf('%.2f',$cpu);
 
 
-    my $cdb = esmith::ConfigDB->open_ro('contentfilter');
+    my $cdb = esmith::ConfigDB->open_ro('contentfilter') || esmith::ConfigDB->create('contentfilter');
     $ret->{'filter'}{'profiles'} = scalar $cdb->get_all();
     $ret->{'filter'}{'status'} = $db->get_prop('ufdb', 'status');
     $ret->{'filter'}{'antivirus'} = $db->get_prop('squidclamav', 'status');


### PR DESCRIPTION
```
[root@ns7loc9 ~]# echo '{"action":"status"}' | /usr/bin/sudo /usr/libexec/nethserver/api/nethserver-squid/dashboard/read | jq
Can't call method "get_all" on an undefined value at /usr/libexec/nethserver/api/nethserver-squid/dashboard/read line 125.
```

The esmith database does not exist when we launch the dashboard api