### PR TITLE
Move blue access log to separate file

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
@@ -10,8 +10,6 @@
 
     my $ndb = esmith::NetworksDB->open_ro();
     if ( $ndb->blue() ) {
-        my $ip = $_->prop('ipaddr') || next;
-        my $mask = $_->prop('netmask') || next;
         $OUT.="access_log daemon:/var/log/squid/access_blue.log squid blue\n";
     }
 

--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_95_localnet_log
@@ -9,11 +9,10 @@
     $OUT.="access_log daemon:/var/log/squid/access.log squid localnet\n";
 
     my $ndb = esmith::NetworksDB->open_ro();
-    foreach ( $ndb->blue() ) {
+    if ( $ndb->blue() ) {
         my $ip = $_->prop('ipaddr') || next;
         my $mask = $_->prop('netmask') || next;
-        $OUT.="access_log daemon:/var/log/squid/access.log squid blue\n";
-        last;
+        $OUT.="access_log daemon:/var/log/squid/access_blue.log squid blue\n";
     }
 
 }


### PR DESCRIPTION
- access log for blue is now saved inside /var/log/squid/access_blue.log
- no lightsquid report will be available for blue network
- new log is already rotated by logrotate configuration from squid package

NethServer/dev#5865