### PR TITLE
api: convert local objects to host

### DIFF
--- a/api/proxy/read
+++ b/api/proxy/read
@@ -73,6 +73,7 @@ if ($cmd eq 'bypass-list') {
     foreach ($hdb->get_all()) {
         my %props = $_->props;
         $props{'name'} = $_->key;
+        $props{'type'} = 'host' if ($props{'type'} eq 'local');
         push(@objects, \%props);
     }
 

--- a/api/rules/read
+++ b/api/rules/read
@@ -66,6 +66,7 @@ if ($cmd eq 'rule-list') {
         if ($type eq 'local' || $type eq 'host') {
             my %props = $_->props;
             $props{'name'} = $_->key;
+            $props{'type'} = 'host' if ($props{'type'} eq 'local');
             push(@sources, \%props);
         }
     }


### PR DESCRIPTION
Firewall rules use the 'host' type for source and destination
objects. The 'local' type is not supported.

NethServer/dev#5892