### PR TITLE
api. fix dns host bypass

### DIFF
--- a/api/proxy/read
+++ b/api/proxy/read
@@ -73,7 +73,7 @@ if ($cmd eq 'bypass-list') {
     foreach ($hdb->get_all()) {
         my %props = $_->props;
         $props{'name'} = $_->key;
-        $props{'type'} = 'host' if ($props{'type'} eq 'local');
+        $props{'type'} = 'host' if ($props{'type'} eq 'local' || $props{'type'} eq 'remote');
         push(@objects, \%props);
     }
 

--- a/api/rules/read
+++ b/api/rules/read
@@ -63,7 +63,7 @@ if ($cmd eq 'rule-list') {
     # Objects
     foreach ($hdb->get_all()) {
         my $type = $_->prop('type');
-        if ($type eq 'local' || $type eq 'host' || $type eq {'remote'}) {
+        if ($type eq 'local' || $type eq 'host' || $type eq 'remote') {
             my %props = $_->props;
             $props{'name'} = $_->key;
             $props{'type'} = 'host' if ($props{'type'} eq 'local' || $props{'type'} eq 'remote');

--- a/api/rules/read
+++ b/api/rules/read
@@ -63,10 +63,10 @@ if ($cmd eq 'rule-list') {
     # Objects
     foreach ($hdb->get_all()) {
         my $type = $_->prop('type');
-        if ($type eq 'local' || $type eq 'host') {
+        if ($type eq 'local' || $type eq 'host' || $type eq {'remote'}) {
             my %props = $_->props;
             $props{'name'} = $_->key;
-            $props{'type'} = 'host' if ($props{'type'} eq 'local');
+            $props{'type'} = 'host' if ($props{'type'} eq 'local' || $props{'type'} eq 'remote');
             push(@sources, \%props);
         }
     }


### PR DESCRIPTION
Fix a problem that was saving a DNS bypass host as `remote` and not as `host` into `fwrules`.
Refer to https://github.com/NethServer/dev/issues/5971