### PR TITLE
Fix source bypass filter

### DIFF
--- a/ui/src/views/Proxy.vue
+++ b/ui/src/views/Proxy.vue
@@ -875,7 +875,7 @@ export default {
         return (
           source.type.toLowerCase().includes(query.toLowerCase()) ||
           source.name.toLowerCase().includes(query.toLowerCase()) ||
-          source.Description.toLowerCase().includes(query.toLowerCase()) ||
+          (source.Description && source.Description.toLowerCase().includes(query.toLowerCase())) ||
           (source.IpAddress &&
             source.IpAddress.toLowerCase().includes(query.toLowerCase())) ||
           (source.Address &&


### PR DESCRIPTION
Host objects created by VPN accounts with reserved IP don't have **Description** attribute.
Source bypass filtering has been fixed by checking **Description** attribute existence.

NethServer/dev#6267