### PR TITLE
[Cosmetic] Discard ipset output

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-squid-ipset
+++ b/root/etc/e-smith/events/actions/nethserver-squid-ipset
@@ -25,7 +25,7 @@
 NAME=squid-bypass
 TIMEOUT=43200 # 12 hours
 
-ipset list $NAME 2>/dev/null
+ipset list $NAME >/dev/null
 
 # Create the ipset if not exists
 if [ $? -gt 0 ]; then


### PR DESCRIPTION
Every time the proxy configuration is saved, actions output is logged.
If the squid-bypass ipset has a lot of entries, /var/log/messages
receives many log lines. This pull requests avoids logging the list of
IP in the ipset.