### PR TITLE
Add host-group, cidr, iprange objects to proxy sources

### DIFF
--- a/api/rules/read
+++ b/api/rules/read
@@ -63,7 +63,7 @@ if ($cmd eq 'rule-list') {
     # Objects
     foreach ($hdb->get_all()) {
         my $type = $_->prop('type');
-        if ($type eq 'local' || $type eq 'host' || $type eq 'remote') {
+        if ($type eq 'local' || $type eq 'host' || $type eq 'host-group' || $type eq 'cidr' || $type eq 'iprange' || $type eq 'remote') {
             my %props = $_->props;
             $props{'name'} = $_->key;
             $props{'type'} = 'host' if ($props{'type'} eq 'local' || $props{'type'} eq 'remote');


### PR DESCRIPTION
Add support for the following objects inside the `Rules` page of `Web Proxy` app:
- host-group
- cidr
- iprange

These objects are already available inside the old Server Manager, this is a regression on the new Server Manager.

https://github.com/NethServer/dev/issues/6361