### PR TITLE
Adding cache.log to squid UI

### DIFF
--- a/ui/src/views/Logs.vue
+++ b/ui/src/views/Logs.vue
@@ -35,6 +35,7 @@
           >
             <option selected>/var/log/squid/access.log</option>
             <option>/var/log/squid/access_blue.log</option>
+            <option>/var/log/squid/cache.log</option>
             <option>/var/log/ufdbguard/ufdbguardd.log</option>
           </select>
         </div>


### PR DESCRIPTION
cache.log can explain why your website/domain are blocked by the transparent proxy

This is what you can find

```
2021/04/22 13:06:31 kid1| SECURITY ALERT: on URL: mobile-webview.gmail.com:443
2021/04/22 13:06:45 kid1| SECURITY ALERT: Host header forgery detected on local=90.1.220.216:443 remote=192.168.13.199:52844 FD 94 fl
ags=33 (local IP does not match any domain IP)
```

Actually you have to go the CLI to open this log

https://github.com/NethServer/dev/issues/6496