### PR TITLE
Removed validator of bypass for source and destination

### DIFF
--- a/api/proxy/validate
+++ b/api/proxy/validate
@@ -59,16 +59,6 @@ if ($data['action'] == 'configuration') {
     $hdb = new EsmithDatabase('hosts');
     $fdb = new EsmithDatabase('fwrules');
 
-    # search for existing bypass with the same Host
-    if ($data['action'] == 'create-bypass') {
-        foreach ($fdb->getAll('bypass-src') as $bypass) {
-            list($type, $name) = explode(";",$bypass['Host']);
-            if ($data['Host']['name'] == $name && $data['Host']['type'] == $type) {
-                $v->addValidationError('Host', 'source_already_exists');
-            }
-        }
-    }
-
     $v->declareParameter('status', Validate::SERVICESTATUS);
     if (isset($data['Host']) && $data['Host']) {
         if (!$hdb->getKey($data['Host']['name'])) {


### PR DESCRIPTION
A source or a destination can exist both in the bypass setting

https://github.com/NethServer/dev/issues/6505