### PR TITLE
api: fix bypass validator

### DIFF
--- a/api/proxy/validate
+++ b/api/proxy/validate
@@ -62,9 +62,11 @@ if ($data['action'] == 'configuration') {
     # search for existing bypass with the same Host
     if ($data['action'] == 'create-bypass') {
         foreach ($fdb->getAll($data['type']) as $bypass) {
-            list($type, $name) = explode(";",$bypass['Host']);
-            if ($data['Host']['name'] == $name && $data['Host']['type'] == $type) {
-                $v->addValidationError('Host', $data['type'].'_already_exists');
+            if (isset($bypass['Host'])) { # skip records with only Domains prop
+                list($type, $name) = explode(";",$bypass['Host']);
+                if ($data['Host']['name'] == $name && $data['Host']['type'] == $type) {
+                    $v->addValidationError('Host', $data['type'].'_already_exists');
+                }
             }
         }
     }


### PR DESCRIPTION
Fix regression caused by 251aeaabb1d80f87c366fb12214abe0732cb3057.
When checking destination bypass, skip the ones without Host objects.
Destination bypass by domains are validated just after this loop.

NethServer/dev#6520