### PR TITLE
api: avoid destination domain bypass duplicates

### DIFF
--- a/api/proxy/validate
+++ b/api/proxy/validate
@@ -64,7 +64,7 @@ if ($data['action'] == 'configuration') {
         foreach ($fdb->getAll($data['type']) as $bypass) {
             if (isset($bypass['Host'])) { # skip records with only Domains prop
                 list($type, $name) = explode(";",$bypass['Host']);
-                if ($data['Host']['name'] == $name && $data['Host']['type'] == $type) {
+                if (isset($data['Host']) && $data['Host']['name'] == $name && $data['Host']['type'] == $type) {
                     $v->addValidationError('Host', $data['type'].'_already_exists');
                 }
             }
@@ -82,6 +82,16 @@ if ($data['action'] == 'configuration') {
         foreach ($data['Domains'] as $domain) {
             if (!$vh->evaluate($domain)) {
                 $v->addValidationError('Destination', 'valid_fqdn_domain');
+            }
+        }
+        foreach ($fdb->getAll('bypass-dst') as $bypass) {
+            if (isset($bypass['Domains'])) {
+                foreach ($data['Domains'] as $domain) {
+                    foreach (explode(",",$bypass['Domains']) as $d)
+                    if(trim($domain) == $d) {
+                        $v->addValidationError('Host', 'dst_domain_already_exists');
+                    }
+                }
             }
         }
     }

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -341,6 +341,7 @@
     "invalid_time": "Invalid time format, use 24h format like '12:00'",
     "invalid_user": "Invalid user",
     "invalid_group": "Invalid group",
+    "dst_domain_already_exists": "A bypass already exists for entered domain(s)",
     "bypass-dst_already_exists": "A bypass for the same destination already exists",
     "bypass-src_already_exists": "A bypass for the same source already exists",
     "source_already_exists": "A bypass for the same source already exists",


### PR DESCRIPTION
Without this change, it was possible to create multiple
bypasses for the same domain

This is relative to the test case 7 which was never been implemented.

NethServer/dev#6520