### PR TITLE
Remove host-group support from mark/divert rules

### DIFF
--- a/api/rules/read
+++ b/api/rules/read
@@ -63,7 +63,7 @@ if ($cmd eq 'rule-list') {
     # Objects
     foreach ($hdb->get_all()) {
         my $type = $_->prop('type');
-        if ($type eq 'local' || $type eq 'host' || $type eq 'host-group' || $type eq 'cidr' || $type eq 'iprange' || $type eq 'remote') {
+        if ($type eq 'local' || $type eq 'host' || $type eq 'cidr' || $type eq 'iprange' || $type eq 'remote') {
             my %props = $_->props;
             $props{'name'} = $_->key;
             $props{'type'} = 'host' if ($props{'type'} eq 'local' || $props{'type'} eq 'remote');

--- a/root/etc/e-smith/templates/etc/squid/squid.conf/45marks
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/45marks
@@ -51,7 +51,7 @@
         }
 
         # Supported objects: host, cidr, zone, iprange
-        if ($src !~ /^(host|cidr|zone|iprange|role)/ || !$src_addr) {
+        if ($src !~ /^(host;|cidr;|zone;|iprange;|role;)/ || !$src_addr) {
             next;
         }
         $OUT .= "\n# Rule ".$rule->key.": src: $src action: $action dst: $dst\n";


### PR DESCRIPTION
Changes:
- remove host-group objects from the UI
- improve the template to avoid failure when host-group objects have been already selected

NethServer/dev#6574