### PR TITLE
fix: add mitigation for CVE-2025-54574

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20_acl_00_cve_2025_54574
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20_acl_00_cve_2025_54574
@@ -1,0 +1,7 @@
+#
+# 20_acl_00_cve_2025_54574
+# CVE 2025-5474
+# GHSA-w4gv-vw3f-29g3
+#
+acl URN proto URN
+http_access deny URN


### PR DESCRIPTION
See also: https://github.com/squid-cache/squid/security/advisories/GHSA-w4gv-vw3f-29g3

To test the mitigation, try the following instructions.

On a shell on the machine, start a fake webserver:
```
echo hello > hello.html
python3 -m http.server --bind 127.0.0.1 8080
```

Execute inside another shell:
```
echo -e "GET urn::@127.0.0.1:8080/hello.html? HTTP/1.1\r\n\r\n" |nc 127.0.0.1 3128
```

Before the update, the commands does not return any output and the server logs:
```
127.0.0.1 - - [07/Aug/2025 06:02:37] "GET /hello.html?/uri-res/N2L?urn::@127.0.0.1:8080/hello.html? HTTP/1.1" 200 -
```

Update the machine with the RPM below.

After the update, execute the echo command again:
```
echo -e "GET urn::@127.0.0.1:8080/hello.html? HTTP/1.1\r\n\r\n" |nc 127.0.0.1 3128
```

It should print something like this:
```
HTTP/1.1 403 Forbidden
Server: squid/3.5.20
Mime-Version: 1.0
Date: Thu, 07 Aug 2025 06:04:27 GMT
Content-Type: text/html;charset=utf-8
Content-Length: 3463
X-Squid-Error: ERR_ACCESS_DENIED 0
Vary: Accept-Language
Content-Language: en
X-Cache: MISS from nsec79.test.local
X-Cache-Lookup: NONE from nsec79.test.local:3128
Via: 1.1 nsec79.test.local (squid/3.5.20)
Connection: keep-alive

<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html><head>
...
</body></html>
```

The web server should not log anything because the proxy must not forward the request.